### PR TITLE
Prefer Debianized binary name, if available

### DIFF
--- a/with-editor.el
+++ b/with-editor.el
@@ -125,7 +125,9 @@ please see https://github.com/magit/magit/wiki/Emacsclient."))
          "emacsclient" path
          (cl-mapcan
           (lambda (v) (cl-mapcar (lambda (e) (concat v e)) exec-suffixes))
-          (nconc (cl-mapcon (lambda (v)
+          (nconc (when (boundp 'debian-emacs-flavor)
+                   (list (format ".%s" debian-emacs-flavor)))
+                 (cl-mapcon (lambda (v)
                               (setq v (mapconcat #'identity (reverse v) "."))
                               (list v (concat "-" v) (concat ".emacs" v)))
                             (reverse version-lst))


### PR DESCRIPTION
On Debianized Emacsen, emacsclient is installed as
/usr/bin/emacsclient.FLAVOR.  Prefer that file name if possible, as it’s
likely to be the most accurate.