### PR TITLE
Ignore compiled elisp, the dir file, and generate autoloads file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /with-editor.html
 /with-editor.info
 /with-editor.pdf
+/with-editor-autoloads.el
+*.elc
+dir


### PR DESCRIPTION
This leaves the directory clean when building in a submodule.