### PR TITLE
Add a space in before export command to avoid polluting HISTFILE

### DIFF
--- a/with-editor.el
+++ b/with-editor.el
@@ -566,7 +566,7 @@ This works in `shell-mode', `term-mode' and `eshell-mode'."
            (filter  (process-filter process)))
       (goto-char (process-mark process))
       (process-send-string
-       process (format "export %s=%s\n" envvar
+       process (format " export %s=%s\n" envvar
                        (shell-quote-argument with-editor-sleeping-editor)))
       (while (accept-process-output process 0.1))
       (set-process-filter process filter)


### PR DESCRIPTION
When `with-editor-export-editor` is added to `shell-mode-hook` the export
command is needlessly added to $HISTFILE, adding a space character before the
command doesn't save the command in the history list. This works given that
usually most of Linux distributions usually ship with HISTCONTROL=ignoreboth.