### PR TITLE
* with-editor.el: add autoload cookie for file-name-history-exclude

### DIFF
--- a/with-editor.el
+++ b/with-editor.el
@@ -254,6 +254,7 @@ Note that when a package adds an entry here then it probably
 has a reason to disrespect `server-window' and it likely is
 not a good idea to change such entries.")
 
+;;;###autoload
 (defvar with-editor-file-name-history-exclude nil
   "List of regexps for filenames `server-visit' should no remember.
 When a filename matches any of the regexps, then `server-visit'


### PR DESCRIPTION
With hooks assigned to that variable in both git-rebase.el and git-commit.el
the variable need an autoload cookie for installers that load lazily
(for el-get or at least that's what I understood).

I don't understand why this hasn't come up before. may be something would have changed in either magit side or el-get side.
