### PR TITLE
Add kludge for tramp-make-tramp-file-name signature change

### DIFF
--- a/with-editor.el
+++ b/with-editor.el
@@ -82,8 +82,7 @@
 (require 'cl-lib)
 (require 'dash)
 (require 'server)
-(require 'tramp)
-(require 'tramp-sh nil t)
+(require 'shell)
 
 (and (require 'async-bytecomp nil t)
      (memq 'magit (bound-and-true-p async-bytecomp-allowed-packages))
@@ -516,10 +515,7 @@ which may or may not insert the text into the PROCESS' buffer."
           (with-current-buffer
               (find-file-noselect
                (if (file-name-absolute-p file)
-                   (if (tramp-tramp-file-p default-directory)
-                       (with-parsed-tramp-file-name default-directory nil
-                         (tramp-make-tramp-file-name method user host file hop))
-                     file)
+                   (concat (file-remote-p default-directory) file)
                  (expand-file-name file)))
             (with-editor-mode 1)
             (setq with-editor--pid pid)


### PR DESCRIPTION
```
As of Emacs's dca22e86e0 (Introduce a defstruct `tramp-file-name' as
central data structure, 2017-05-24), tramp-make-tramp-file-name takes
two more positional arguments.  Along with this change, the components
of the filename are stored differently (a defstruct is now used
instead of a vector), so we can use this to distinguish which
tramp-make-tramp-file-name variant we have.
```
Fixes #29.