### PR TITLE
Use process-live-p to check whether process is alive

### DIFF
--- a/with-editor.el
+++ b/with-editor.el
@@ -457,7 +457,7 @@ ENVVAR is provided then bind that environment variable instead.
     (unless (featurep 'make-network-process '(:family local))
       (setq server-use-tcp t))
     ;; Make sure the server is running.
-    (unless server-process
+    (unless (process-live-p server-process)
       (when (server-running-p server-name)
         (setq server-name (format "server%s" (emacs-pid)))
         (when (server-running-p server-name)


### PR DESCRIPTION
When `server-process` dies, it still keeps the reference to the died
process with status `closed` and is evaluated as non-nil, therefore does
not restart correctly in such cases.