### PR TITLE
Fix with-editor-export-editor for term-mode.

### DIFF
--- a/with-editor.el
+++ b/with-editor.el
@@ -176,7 +176,7 @@ please see https://github.com/magit/magit/wiki/Emacsclient."))))
 
 (defcustom with-editor-sleeping-editor "\
 sh -c '\
-echo \"WITH-EDITOR: $$ OPEN $0 IN $(pwd)\"; \
+echo -e \"WITH-EDITOR: $$ OPEN $0\\037 IN $(pwd)\"; \
 sleep 604800 & sleep=$!; \
 trap \"kill $sleep; exit 0\" USR1; \
 trap \"kill $sleep; exit 1\" USR2; \


### PR DESCRIPTION
Fix #70 

The previous value of `with-editor-sleeping-editor` variable was using the \x1f
character in the ELisp string and sending it to the shell/term process.

For `shell-mode` this is not an issue since the character is not interpreted by
the shell. But in `term-mode` the terminal emulation interprets it and remove
previous characters, the "$0" string. So we end up with an EDITOR environment
variable that contains an echo command with "…OPEN IN…" instead of "…OPEN $0^_
IN…" (here "^_" is used to represent the \x1f byte).

This change fixes the issue by using `-e` flag of `echo` and use the `\037`
octal escape sequence for the \x1f byte.