### PR TITLE
with-editor-export-editor: Use printf instead of echo.

### DIFF
--- a/with-editor.el
+++ b/with-editor.el
@@ -176,7 +176,7 @@ please see https://github.com/magit/magit/wiki/Emacsclient."))))
 
 (defcustom with-editor-sleeping-editor "\
 sh -c '\
-echo -e \"WITH-EDITOR: $$ OPEN $0\\037 IN $(pwd)\"; \
+printf \"WITH-EDITOR: $$ OPEN $0\\037 IN $(pwd)\\n\"; \
 sleep 604800 & sleep=$!; \
 trap \"kill $sleep; exit 0\" USR1; \
 trap \"kill $sleep; exit 1\" USR2; \


### PR DESCRIPTION
The `-e` flag of `echo` that makes the command interpret backslash-escaped
sequences (in particular "\037") is not supported in all shells.

Shells that don't support it prints the flag instead.

So here we replace `echo` by `printf` which seems to be better supported and
does the interpretation of backslash-escaped sequence by default.