### PR TITLE
with-editor-export-editor: check whether there is a buffer process

### DIFF
--- a/with-editor.el
+++ b/with-editor.el
@@ -697,7 +697,7 @@ This works in `shell-mode', `term-mode', `eshell-mode' and
   (interactive (list (with-editor-read-envvar)))
   (cond
    ((derived-mode-p 'comint-mode 'term-mode)
-    (let ((process (get-buffer-process (current-buffer))))
+    (when-let ((process (get-buffer-process (current-buffer))))
       (goto-char (process-mark process))
       (process-send-string
        process (format " export %s=%s\n" envvar


### PR DESCRIPTION
When `with-editor-export-editor` is added to the `shell-mode-hook`, it's
also executed by `shell-command`, because it calls `shell-mode`, which
inherits from `comint-mode'`  Usually, `shell-command` is used to
execute short-lived process, hence there might not be a process
associated to the buffer when the hook is executed.

The previous implementation assumed the existence of a process
associated to a buffer, which might not be a case on `shell-command`
buffers. This change intends to checks whether there is a process
associated before sending the environment variables.
