### PR TITLE
Fix vterm hook documentation

### DIFF
--- a/docs/with-editor.org
+++ b/docs/with-editor.org
@@ -187,7 +187,7 @@ mode hooks:
   (add-hook 'shell-mode-hook  'with-editor-export-editor)
   (add-hook 'eshell-mode-hook 'with-editor-export-editor)
   (add-hook 'term-exec-hook   'with-editor-export-editor)
-  (add-hook 'vterm-exec-hook  'with-editor-export-editor)
+  (add-hook 'vterm-mode-hook  'with-editor-export-editor)
 #+end_src
 
 Some variants of this function exist; these two forms are equivalent:

--- a/docs/with-editor.texi
+++ b/docs/with-editor.texi
@@ -247,7 +247,7 @@ mode hooks:
 (add-hook 'shell-mode-hook  'with-editor-export-editor)
 (add-hook 'eshell-mode-hook 'with-editor-export-editor)
 (add-hook 'term-exec-hook   'with-editor-export-editor)
-(add-hook 'vterm-exec-hook  'with-editor-export-editor)
+(add-hook 'vterm-mode-hook  'with-editor-export-editor)
 @end lisp
 
 Some variants of this function exist; these two forms are equivalent:


### PR DESCRIPTION
This seems to work properly only with vterm-mode-hook, not with vterm-exec-hook. with-editor.el correctly mentions vterm-mode-hook, but the documentation refers to vterm-exec-hook.