### PR TITLE
Append newline to emacsclient command

### DIFF
--- a/lisp/with-editor.el
+++ b/lisp/with-editor.el
@@ -382,7 +382,7 @@ And some tools that do not handle $EDITOR properly also break."
                  (dolist (client clients)
                    (message "client %S" client)
                    (ignore-errors
-                     (server-send-string client "-error Canceled by user"))
+                     (server-send-string client "-error Canceled by user\n"))
                    (delete-process client))
                  (when (buffer-live-p buf)
                    (kill-buffer buf)))


### PR DESCRIPTION
In the next Emacs release, emacsclient will be pickier about requiring a newline at the end of every command you send it. This is so that it can distinguish command ends from dropped connections.  So, put a newline at the end of the -error command that with-editor-return can send.
