### PR TITLE
Use add-function to append process filter instead of replacing it

### DIFF
--- a/lisp/with-editor.el
+++ b/lisp/with-editor.el
@@ -8,7 +8,7 @@
 
 ;; Package-Version: 3.5.0
 ;; Package-Requires: (
-;;     (emacs   "26.1")
+;;     (emacs   "28.1")
 ;;     (compat  "31.0")
 ;;     (cond-let "1.0"))
 
@@ -922,10 +922,9 @@ Also take care of that for `with-editor-[async-]shell-command'."
                            (or output-buffer
                                (get-buffer "*Async Shell Command*")))))
          (prog1 process
-           (set-process-filter process
-                               (lambda (proc str)
-                                 (comint-output-filter proc str)
-                                 (with-editor-process-filter proc str t))))))
+           (add-function :after (process-filter process)
+                         (lambda (proc str)
+                           (with-editor-process-filter proc str t))))))
       ((funcall fn command output-buffer error-buffer)))))
 
 ;;; _


### PR DESCRIPTION
When `async-shell-command-display-buffer` is nil, the display of the
shell command buffer is delayed until there is output.  This is
achieved by adding a function to the process filter.  Previously we
replaced that filter, which prevented the intended delayed display.
Use `add-function` to append our filter instead.